### PR TITLE
clean compile with compiler flags /WX /W4

### DIFF
--- a/range/CMakeLists.txt
+++ b/range/CMakeLists.txt
@@ -20,7 +20,6 @@ function(CreateStandalone CS_Dest)
 	endforeach()
 endfunction()
 
-
 # Require boost system library
 find_package(Boost 1.59 COMPONENTS system REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
@@ -29,10 +28,10 @@ set(LIBRARIES ${LIBRARIES} ${Boost_LIBRARIES})
 if (MSVC)
 	add_definitions(-DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS)
 
-	set(CMAKE_CXX_FLAGS_DEBUG "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1")
-    set(CMAKE_CXX_FLAGS_MINSIZEREL     "/MT /O1 /Ob1 /D NDEBUG")
-    set(CMAKE_CXX_FLAGS_RELEASE        "/MT /O2 /Ob2 /D NDEBUG")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MT /Zi /O2 /Ob1 /D NDEBUG")
+	set(CMAKE_CXX_FLAGS_DEBUG          "/W4 /WX /MTd /Od /Ob0 /D_DEBUG /Zi /RTC1")
+	set(CMAKE_CXX_FLAGS_MINSIZEREL     "/W4 /WX /MT  /O1 /Ob1 /DNDEBUG")
+	set(CMAKE_CXX_FLAGS_RELEASE        "/W4 /WX /MT  /O2 /Ob2 /DNDEBUG")
+	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/W4 /WX /MT  /O2 /Ob1 /DNDEBUG /Zi")
 else ()
 	add_definitions(-DCLANG)
 
@@ -108,7 +107,7 @@ set(Header
 	union_adaptor.h
 	unique_range_adaptor.h
 	zip_range.h
-   )
+)
 source_group(Header FILES ${Header})
 
 set(Tests
@@ -139,15 +138,12 @@ set(Build
 )
 source_group(Build FILES ${Build})
 
-
 # create a test runner
 add_definitions(-DPERFORMUNITTESTS -DBOOST_RANGE_ENABLE_CONCEPT_ASSERT=0)
 
 foreach(Example ${Examples})
 	add_executable(example_${Example} ${Build} ${Header} ${Tests} ${Example})
-    target_link_libraries(example_${Example} ${LIBRARIES})
+	target_link_libraries(example_${Example} ${LIBRARIES})
 endforeach()
 
 CreateStandalone("StandaloneRanges/Library/Utilities/Range" FILES ${Build} ${Header} ${Tests} ${Examples})
-
-

--- a/range/algorithm.h
+++ b/range/algorithm.h
@@ -2,14 +2,14 @@
 // think-cell public library
 // Copyright (C) 2016 think-cell Software GmbH
 //
-// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as 
-// published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. 
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 //
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty 
-// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License along with this program. 
-// If not, see <http://www.gnu.org/licenses/>. 
+// You should have received a copy of the GNU General Public License along with this program.
+// If not, see <http://www.gnu.org/licenses/>.
 //-----------------------------------------------------------------------------------------------------------------------------
 
 #pragma once
@@ -58,8 +58,8 @@
 #pragma warning(push)
 #pragma warning( disable: 4267 )
 // warning C4267 : 'argument' : conversion from 'size_t' to 'int', possible loss of data
-// _Median(...) causes warning C4267 when difference_type is int and size_t is 64 bit. 
-// Stephan T. Lavavej [stl@exchange.microsoft.com] agrees this is a bug and filed DevDiv#1213041 
+// _Median(...) causes warning C4267 when difference_type is int and size_t is 64 bit.
+// Stephan T. Lavavej [stl@exchange.microsoft.com] agrees this is a bug and filed DevDiv#1213041
 // "<algorithm>: _Median() doesn't handle fancy difference types" to track the problem.
 #include <algorithm>
 #pragma warning(pop)
@@ -365,7 +365,7 @@ namespace tc {
 		struct assign final {
 			assign(T (&at)[N]) noexcept
 			: m_at(at) {}
-			
+
 			template< typename Rhs >
 			void operator()( Rhs&& rhs ) & noexcept {
 				m_at[m_i]=std::forward<Rhs>(rhs);
@@ -745,7 +745,7 @@ namespace tc {
 #else
 				0;
 			Cont
-#endif				
+#endif
 				cont;
 			tc::cont_clear(cont, 0<cont.capacity() ? cont.capacity() : tc::numeric_cast<typename Cont::size_type>(8)/*, boost::container::default_init*/);
 
@@ -755,7 +755,7 @@ namespace tc {
 				 [&]() noexcept {
 					tc::uninitialize(tc_back(cont));
 					scope_exit( _ASSERTDEBUG( !tc::check_initialized(tc_back(cont))) );
-					return 
+					return
 #endif
 						func(tc::ptr_begin(cont), tc::size(cont)-nSentinel);
 #if defined _DEBUG && !defined __clang__
@@ -796,12 +796,12 @@ namespace tc {
 			tc::cont_clear(cont,tc::max(cont.capacity(),nSentinel)/*, boost::container::default_init*/);
 
 			for (;;) {
-				auto const nSize = 
+				auto const nSize =
 #if defined _DEBUG && !defined __clang__
 				 [&]() MAYTHROW {
 					tc::fill_with_dead_pattern(tc_back(cont));
 					scope_exit( tc::assert_dead_pattern(tc_back(cont)) );
-					return 
+					return
 #endif
 					func(tc::ptr_begin(cont), tc::size(cont)-nSentinel); // MAYTHROW
 #if defined _DEBUG && !defined __clang__
@@ -862,7 +862,7 @@ namespace tc {
 	}
 
 	template< typename Cont, typename It, std::enable_if_t<!is_instance<std::multiset,Cont>::value && !is_instance<std::multimap,Cont>::value && !is_instance<boost::intrusive::multiset,Cont>::value>* = nullptr >
-	It && verify_at_upper_bound(Cont const& cont, It&& it) noexcept {
+	It && verify_at_upper_bound(Cont const&, It&& it) noexcept {
 		return std::forward<It>(it);
 	}
 
@@ -938,7 +938,7 @@ namespace tc {
 			tc::assign_better(it->second, std::forward<V>(val), std::forward<Better>(better));
 		}
 	}
-	
+
 	template< typename... MapArgs, typename K, typename... MappedTypeCtorArgs >
 	std::pair< typename std::map<MapArgs...>::iterator, bool > map_try_emplace_with_key(std::map<MapArgs...>& map, K&& key, MappedTypeCtorArgs&& ... mappedtypectorargs) noexcept {
 		// TODO C++17: Use std::map::try_emplace
@@ -1005,7 +1005,7 @@ namespace tc {
 	struct range_filter;
 
 	template<typename Cont>
-	struct range_filter<Cont, std::enable_if_t< 
+	struct range_filter<Cont, std::enable_if_t<
 		has_efficient_erase<Cont>::value
 		|| has_mem_fn_lower_bound<Cont>::value
 		|| has_mem_fn_hash_function<Cont>::value
@@ -1060,7 +1060,7 @@ namespace tc {
 	};
 
 	template<typename Cont>
-	struct range_filter< Cont, std::enable_if_t< 
+	struct range_filter< Cont, std::enable_if_t<
 		has_mem_fn_splice_after< Cont >::value
 	> >: Cont, private tc::noncopyable {
 		static_assert( tc::is_decayed< Cont >::value, "" );
@@ -1100,14 +1100,14 @@ namespace tc {
 	};
 
 	template<typename Cont>
-	struct range_filter< Cont, std::enable_if_t< 
+	struct range_filter< Cont, std::enable_if_t<
 		has_mem_fn_splice<Cont >::value
 	> >: Cont, private tc::noncopyable {
 		static_assert( tc::is_decayed< Cont >::value, "" );
 		Cont& m_contInput;
 		using typename Cont::iterator;
 		using const_iterator = iterator; // no deep constness (analog to sub_range)
-	
+
 		explicit range_filter(Cont& cont) noexcept
 			: m_contInput(cont)
 		{}
@@ -1124,7 +1124,7 @@ namespace tc {
 
 		void keep(iterator it) & noexcept {
 			_ASSERT( it!=boost::end(m_contInput) );
-			this->splice( 
+			this->splice(
 				boost::end(*this),
 				m_contInput,
 				m_contInput.erase( boost::begin(m_contInput), it )
@@ -1173,7 +1173,7 @@ namespace tc {
 
 		void keep(iterator it) & noexcept {
 #ifdef _CHECKS
-			// Filter without reordering 
+			// Filter without reordering
 			_ASSERT( 0<=std::distance(m_itFirstValid,it) );
 			m_itFirstValid=it;
 			++m_itFirstValid;
@@ -1612,7 +1612,7 @@ namespace tc {
 		}
 	}
 
-	template< typename RngA, typename RngB, typename Comp, typename FuncElementA, typename FuncElementB, typename FuncElementBoth > 
+	template< typename RngA, typename RngB, typename Comp, typename FuncElementA, typename FuncElementB, typename FuncElementBoth >
 	break_or_continue interleave_may_remove_current(RngA&& rngA, RngB&& rngB, Comp comp, FuncElementA fnElementA, FuncElementB fnElementB,  FuncElementBoth fnElementBoth) noexcept {
 		auto itA=boost::begin(rngA);
 		auto itEndA=boost::end(rngA);

--- a/range/algorithm.h
+++ b/range/algorithm.h
@@ -47,6 +47,7 @@
 #include <boost/range/algorithm/stable_sort.hpp>
 
 #include <boost/multi_index_container_fwd.hpp>
+#include <boost/intrusive/set.hpp>
 
 #include <type_traits>
 #include <set>
@@ -860,12 +861,12 @@ namespace tc {
 		return std::forward<It>(it);
 	}
 
-	template< typename Cont, typename It, std::enable_if_t<!is_instance<std::multiset,Cont>::value && !is_instance<std::multimap,Cont>::value>* = nullptr >
+	template< typename Cont, typename It, std::enable_if_t<!is_instance<std::multiset,Cont>::value && !is_instance<std::multimap,Cont>::value && !is_instance<boost::intrusive::multiset,Cont>::value>* = nullptr >
 	It && verify_at_upper_bound(Cont const& cont, It&& it) noexcept {
 		return std::forward<It>(it);
 	}
 
-	template< typename Cont, typename It, std::enable_if_t<is_instance<std::multiset,Cont>::value || is_instance<std::multimap,Cont>::value>* = nullptr >
+	template< typename Cont, typename It, std::enable_if_t<is_instance<std::multiset,Cont>::value || is_instance<std::multimap,Cont>::value || is_instance<boost::intrusive::multiset,Cont>::value>* = nullptr >
 	It && verify_at_upper_bound(Cont const& cont, It&& it) noexcept {
 #ifdef _DEBUG
 		/* standard says: the inserted element has to be placed at upper bound */

--- a/range/algorithm.t.cpp
+++ b/range/algorithm.t.cpp
@@ -16,6 +16,8 @@
 #include "container.h" // tc::vector
 #include "range.t.h"
 
+#include <boost/core/ignore_unused.hpp>
+
 namespace {
 	using namespace tc;
 
@@ -86,6 +88,7 @@ UNITTESTDEF(filter_no_self_assignment_of_rvalues) {
 
 		S& operator=(S&& other) {
 			_ASSERT(&other != this);
+			boost::ignore_unused(other);
 			return *this;
 		}
 	};
@@ -114,40 +117,49 @@ UNITTESTDEF( is_sorted ) {
 	{
 		int a[]={0};
 		_ASSERT( tc::is_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={0,0};
 		_ASSERT( tc::is_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={0,1};
 		_ASSERT( tc::is_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={1,0};
 		_ASSERT( !tc::is_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={0};
 		_ASSERT( tc::is_strictly_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={0,0};
 		_ASSERT( !tc::is_strictly_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={0,1};
 		_ASSERT( tc::is_strictly_sorted(a) );
+		boost::ignore_unused(a);
 	}
 	{
 		int a[]={1,0};
 		_ASSERT( !tc::is_strictly_sorted(a) );
+		boost::ignore_unused(a);
 	}
 }
 
 UNITTESTDEF( make_vector_on_r_vector_is_identity ) {
 	tc::vector<int> v{1,2,3};
 	auto pvecdata = v.data();
+	boost::ignore_unused(pvecdata);
 
 	auto vNew = tc::make_vector(tc_move(v));
 	_ASSERT( vNew.data() == pvecdata );
@@ -177,6 +189,7 @@ UNITTESTDEF(find_closest_if) {
 		for (int nTarget = -1; nTarget < 4; ++nTarget) {
 			int nComparisonsMax = -1==nTarget ? 5 : nTarget<iStart ? 2*(iStart-nTarget) : 1+2*(nTarget-iStart);
 			_ASSERTEQUAL(find(std::initializer_list<IntCompareOnce>{{0},{1},{2},{3},{4}}, iStart, nTarget, nComparisonsMax), nTarget);
+			boost::ignore_unused(nComparisonsMax);
 		}
 	}
 }

--- a/range/array.h
+++ b/range/array.h
@@ -24,6 +24,7 @@
 #include "explicit_cast.h"
 #include <cstdint>
 #include <boost/iterator/indirect_iterator.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 namespace tc {
 	struct fill_tag final {};
@@ -186,6 +187,7 @@ namespace tc {
 				: m_a{*it, (IndexPack, *++it)...}
 			{
 				_ASSERT(itEnd==++it);
+				boost::ignore_unused(itEnd);
 			}
 		public:
 			template< typename Rng,
@@ -360,6 +362,7 @@ namespace tc {
 			{
 				static_assert(tc::creates_no_reference_to_temporary<decltype(*it), T&>::value, "*it must return a reference to T or derived type");
 				_ASSERT(itEnd==++it);
+				boost::ignore_unused(itEnd);
 			}
 		public:
 			template< typename Rng,

--- a/range/compare.h
+++ b/range/compare.h
@@ -51,12 +51,13 @@ namespace tc {
 	template<typename T, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
 	void assert_not_isnan(T const& t) noexcept {
 		_ASSERT( !std::isnan(t) );
+		boost::ignore_unused(t);
 	}
 
 	// specialization for wchar_t in MSVC does not have has_quiet_NAN:
 	// std::enable_if_t<!(std::numeric_limits<T>::has_quiet_NAN || std::numeric_limits<T>::has_signaling_NAN) >
 	template<typename T, std::enable_if_t<!std::is_floating_point<T>::value>* = nullptr>
-	void assert_not_isnan(T const& t) noexcept {}
+	void assert_not_isnan(T const&) noexcept {}
 }
 
 // not inside tc namespace, so that compare below has no chance seeing tc::compare

--- a/range/const.t.cpp
+++ b/range/const.t.cpp
@@ -68,7 +68,7 @@ UNITTESTDEF( const_range ) {
 // filter constness tests
 
 template <typename Rng, typename Func>
-void test_const_filter(filter_adaptor<Func, Rng> const& f) noexcept {
+void test_const_filter(filter_adaptor<Func, Rng> const& /*f*/) noexcept {
 
 	//filter_adaptor<Func, Rng> non_const_should_fail(f); // do not add ctor_const_overload() here, you would be lying
 //	filter_adaptor<Func, Rng> const const_filter(f, ctor_const_overload());
@@ -125,7 +125,7 @@ UNITTESTDEF( filter_filter_const_move_test ) {
 // transform constness tests
 
 template <typename Rng, typename Func>
-void test_const_transform(transform_adaptor<Func, Rng> const& t) noexcept {
+void test_const_transform(transform_adaptor<Func, Rng> const& /*t*/) noexcept {
 
 	//transform_adaptor<Func, Rng> non_const_should_fail(t); // do not add ctor_const_overload() here, you would be lying
 //	transform_adaptor<Func, Rng> const const_transform(t, ctor_const_overload());

--- a/range/is_static_castable.h
+++ b/range/is_static_castable.h
@@ -30,6 +30,7 @@ namespace tc {
 
 #pragma warning (push)
 #pragma warning (disable: 4822) //  local class member function does not have a body
+#pragma warning (disable: 4505) //  unreferenced local function has been removed
 	static void Test() noexcept {
 		struct S {};
 		struct T : S {};

--- a/range/merge_ranges.t.cpp
+++ b/range/merge_ranges.t.cpp
@@ -17,6 +17,7 @@
 #include "compare.h"
 
 #include <boost/fusion/include/make_fused_function_object.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include "merge_ranges.h"
 
 UNITTESTDEF(merge_ranges_with_simple_usecase) {
@@ -30,9 +31,11 @@ UNITTESTDEF(merge_ranges_with_simple_usecase) {
 		tc::merge_many(vecvecn),
 		[&](int const& n) noexcept {
 			_ASSERTEQUAL(n, ++N);
+			boost::ignore_unused(n);
 		}
 	);
 	_ASSERT(N==5);
+	boost::ignore_unused(N);
 }
 
 
@@ -57,6 +60,8 @@ UNITTESTDEF(zip_range_adaptor_test) {
 					_ASSERTEQUAL(std::addressof(*it), std::addressof(n));
 					_ASSERTEQUAL(std::addressof(*it2), std::addressof(n2));
 					++it; ++it2;
+					boost::ignore_unused(n);
+					boost::ignore_unused(n2);
 				}
 			)
 		);
@@ -76,6 +81,8 @@ UNITTESTDEF(zip_range_adaptor_test) {
 			[&](int const& n, int const& n2) noexcept {
 				VERIFYEQUAL(N, n) /= 2;
 				++VERIFYEQUAL(N2, n2);
+				boost::ignore_unused(n);
+				boost::ignore_unused(n2);
 			}
 		)
 	);
@@ -119,6 +126,7 @@ UNITTESTDEF(merge_ranges_with_unique_range_2) {
 						second = n;
 						_ASSERTEQUAL(first, n+1);
 						++nTotal;
+						boost::ignore_unused(first);
 					}
 				)
 			);

--- a/range/minmax.h
+++ b/range/minmax.h
@@ -21,7 +21,7 @@ namespace tc {
 			_ASSERT(-1!=t);
 		}
 		template<typename T, std::enable_if_t<!(tc::is_instance<tc::size_proxy,T>::value && std::is_signed<T>::value)>* =nullptr>
-		void AssertSizeProxy(T const& t) {}
+		void AssertSizeProxy(T const&) {}
 		
 		template<typename Better>
 		struct best_impl final {

--- a/range/range.example.cpp
+++ b/range/range.example.cpp
@@ -16,8 +16,8 @@ void basic () {
 
    auto evenvr = tc::filter(v, [](const int& v){ return (v%2==0);});
 
-   for (auto& v: evenvr) {
-      std::cout << v << ", ";
+   for (auto& var: evenvr) {
+      std::cout << var << ", ";
    }
    std::cout << std::endl;
 }

--- a/range/range.t.cpp
+++ b/range/range.t.cpp
@@ -232,6 +232,7 @@ UNITTESTDEF( zero_termination ) {
 		// _ASSERTEQUAL( tc::size(ach), 1 ); // does not compile
 		char const* pch=ach;
 		_ASSERTEQUAL( tc::size(pch), 1 );
+		boost::ignore_unused(pch);
 	}
 	{
 		signed char const ach[]={ 0x20, 0 };
@@ -332,6 +333,7 @@ UNITTESTDEF( construct_array_from_range ) {
 		_ASSERTEQUAL(tc::size(avecn[n]), 0);
 		_ASSERTEQUAL(tc::size(avecnRef[n]), 0);
 		_ASSERTEQUAL(tc::size(avecnMoved[n]), n);
+		boost::ignore_unused(n);
 	});
 }
 

--- a/range/range_defines.h
+++ b/range/range_defines.h
@@ -38,13 +38,13 @@
 		#define _ASSERTNOTIFYFALSE _ASSERTFALSE
 	#endif
 	#ifndef _ASSERTEQUAL
-			#define _ASSERTEQUAL(a, b) assert((a)==(b))
+			#define _ASSERTEQUAL(a, b) _ASSERT((a)==(b))
 	#endif
 	#ifndef _ASSERTINITIALIZED
 		#define _ASSERTINITIALIZED( expr ) (expr)
 	#endif
 	#ifndef _ASSERTPRINT
-		#define _ASSERTPRINT( cond, ... ) assert( cond )
+		#define _ASSERTPRINT( cond, ... ) _ASSERT( cond )
 	#endif
 	#ifndef VERIFYEQUAL
 		#define VERIFYEQUAL( expr, constant ) (expr)

--- a/range/renew.h
+++ b/range/renew.h
@@ -29,6 +29,7 @@ namespace tc {
 	template< typename T >
 	void dtor( T & t ) noexcept { // can call dtor on const&, but does not seem sensible
 		t.~T();
+		boost::ignore_unused(t);
 #ifdef _DEBUG
 		// static_cast<void*> to silence warning: destination for this 'memset' call is a pointer to dynamic class; vtable pointer will be overwritten [-Wdynamic-class-memaccess]
 		std::memset( static_cast<void*>(std::addressof(t)), 0xcc, sizeof( t ) );

--- a/range/sub_range.h
+++ b/range/sub_range.h
@@ -489,6 +489,7 @@ namespace tc {
 	template< typename It, typename Rng >
 	It && verify_not_end(It&& it, Rng const& rng) noexcept {
 		_ASSERT(boost::end(rng) != it);
+		boost::ignore_unused(rng);
 		return std::forward<It>(it);
 	}
 
@@ -881,7 +882,7 @@ namespace tc {
 	struct return_border final {
 		using type = typename boost::range_iterator< std::remove_reference_t<Rng> >::type;
 
-		static type pack_border(typename boost::range_iterator< std::remove_reference_t<Rng> >::type it, Rng&& rng) noexcept {
+		static type pack_border(typename boost::range_iterator< std::remove_reference_t<Rng> >::type it, Rng&&) noexcept {
 			return it;
 		}
 	};
@@ -930,7 +931,7 @@ namespace tc {
 		static type pack_view(Anything&&, It&&, It&&) noexcept {
 			return true;
 		}
-		static type pack_no_element(Rng&& rng) noexcept {
+		static type pack_no_element(Rng&&) noexcept {
 			return false;
 		}
 	};
@@ -959,7 +960,7 @@ namespace tc {
 		static type pack_element(typename boost::range_iterator< std::remove_reference_t<Rng> >::type it, Rng&&, Ref&&) noexcept {
 			return static_cast<type>(it);
 		}
-		static type pack_no_element(Rng&& rng) noexcept {
+		static type pack_no_element(Rng&&) noexcept {
 			return type{}; // value initialization to initialize pointers to nullptr
 		}
 	};
@@ -1083,7 +1084,7 @@ namespace tc {
 		using type = typename boost::range_iterator< std::remove_reference_t<Rng> >::type;
 
 		template<typename Ref>
-		static type pack_element(typename boost::range_iterator< std::remove_reference_t<Rng> >::type it, Rng&& rng, Ref&&) noexcept {
+		static type pack_element(typename boost::range_iterator< std::remove_reference_t<Rng> >::type it, Rng&&, Ref&&) noexcept {
 			return boost::next(it);
 		}
 		static type pack_view(Rng&&, typename boost::range_iterator< std::remove_reference_t<Rng> >::type, typename boost::range_iterator< std::remove_reference_t<Rng> >::type itEnd) noexcept {

--- a/range/sub_range.t.cpp
+++ b/range/sub_range.t.cpp
@@ -28,36 +28,6 @@ namespace {
 	using namespace tc;
 
 	//-------------------------------------------------------------------------------------------------------------------------
-	// make_sub_range_result stanity checks
-	namespace sub_range_detail{
-		template< typename Rng > struct make_sub_range_result_tests final {
-			template <typename Lhs, typename Rhs> static void test_const_ref_variants() noexcept {
-				//static_assert(std::is_same< typename make_sub_range_result<Lhs>::type, sub_range<Rhs> >::value, "make_sub_range_result(Rng) gives wrong result");
-				//static_assert(std::is_same< typename make_sub_range_result<Lhs&>::type, sub_range<Rhs&> >::value, "make_sub_range_result(Rng&) gives wrong result");
-				//static_assert(std::is_same< typename make_sub_range_result<Lhs const>::type, sub_range<Rhs const> >::value, "make_sub_range_result(Rng const) gives wrong result");
-				//static_assert(std::is_same< typename make_sub_range_result<Lhs const&>::type, sub_range<Rhs const&> >::value, "make_sub_range_result(Rng const&) gives wrong result");
-			}
-
-			static void test_sub_range_unrolling() noexcept {
-				test_const_ref_variants<Rng, Rng>();
-				test_const_ref_variants<sub_range<Rng>, Rng>();
-				test_const_ref_variants<sub_range<sub_range<Rng>>, Rng>();
-				test_const_ref_variants<sub_range<sub_range<sub_range<sub_range<sub_range<Rng>>>>>, Rng>(); // "proof" of induction
-			}
-
-			static void test() noexcept {
-				test_sub_range_unrolling();
-			}
-		};
-
-		static void test_make_sub_range_result() noexcept {
-			make_sub_range_result_tests<tc::vector<int>>::test();
-			make_sub_range_result_tests<std::string>::test();
-			//make_sub_range_result_tests<tc::bstr>::test();
-		}
-	}
-
-	//-------------------------------------------------------------------------------------------------------------------------
 
 	using SRVI = make_sub_range_result<tc::vector<int>&>::type;
 	using CSRVI = make_sub_range_result<tc::vector<int> const&>::type;

--- a/range/type_traits_t.cpp
+++ b/range/type_traits_t.cpp
@@ -16,6 +16,7 @@
 #include "type_traits.h"
 #include "range.t.h"
 
+#include <boost/core/ignore_unused.hpp>
 
 static_assert(std::is_same< tc::remove_rvalue_reference_t<int>, int >::value, "");
 static_assert(std::is_same< tc::remove_rvalue_reference_t<int const>, int const >::value, "");
@@ -194,11 +195,11 @@ struct S{
 		tc::cont_must_emplace(g_sets, this);
 	}
 
-	S(S const& other) {
+	S(S const&) {
 		tc::cont_must_emplace(g_sets, this);
 	}
 
-	S(S&& other) {
+	S(S&&) {
 		tc::cont_must_emplace(g_sets, this);
 	}
 
@@ -225,6 +226,8 @@ struct S{
 	friend bool operator<(S const& lhs, S const& rhs) {
 		_ASSERT(boost::end(g_sets) != g_sets.find(std::addressof(lhs)));
 		_ASSERT(boost::end(g_sets) != g_sets.find(std::addressof(rhs)));
+		boost::ignore_unused(lhs);
+		boost::ignore_unused(rhs);
 		return true;
 	}
 };

--- a/range/zip_range.h
+++ b/range/zip_range.h
@@ -142,7 +142,7 @@ namespace tc {
 			}
 
 #ifdef _CHECKS
-			bool all_at_end_index(index const& idx, std::index_sequence<>) const& noexcept {
+			bool all_at_end_index(index const&, std::index_sequence<>) const& noexcept {
 				return true;
 			}
 


### PR DESCRIPTION
Dear Tobias,

I use /WX and /W4 in my projects. This commit tidies up some minor compile issues. The boost::ignore_unused might be replaced with a better VERIFYEQUAL mock-up. In general, I think we should add proper default implementations for VERIFYEQUAL, _ASSERTPRINT instead of empty mock-ups.

Best
Jens