### PR TITLE
bump clang version to 13 or fails under clang 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You need to have boost installed (we tested with [1.75.0](https://www.boost.org/
 ##### Visual C++ 19.28 (Visual Studio 2019 16.9)
 * `/std:c++latest`
 
-##### clang (*10.0.0* and *Apple LLVM 12.0.0*)
+##### clang (*10.0.0* and *Apple LLVM 12.0.0*, or *clang 13* but not clang 11)
 * `-std=c++2a`
 
 `range.example.cpp` provides a good entry point to get started quickly. If you want to see more examples, there are some unit tests in `tc/*.t.cpp`.


### PR DESCRIPTION
the error with clang11 was:

$ clang++-11 -std=c++2a -c range.example.cpp
In file included from range.example.cpp:11:
In file included from ./tc/string/format.h:14:
./tc/string/../algorithm/empty.h:29:108: error: a non-type template parameter cannot have type 'std::integral_constant<tc::break_or_continue_adl::break_or_continue, tc::break_or_continue_adl::break_or_continue::break_>'
return [&](https://github.com/think-cell/range/pull/23) return_MAYTHROW(tc::continue_==tc::for_each(tc_move_if_owned(rng), tc::constexpr_function<tc::constanttc::break_{}>()));
^
./tc/range/../algorithm/../base/trivial_functors.h:26:17: note: template parameter is declared here
template
^
In file included from range.example.cpp:11:
In file included from ./tc/string/format.h:14:
./tc/string/../algorithm/empty.h:29:108: error: a non-type template parameter cannot have type 'std::integral_constant<tc::break_or_continue_adl::break_or_continue, tc::break_or_continue_adl::break_or_continue::break_>'
return [&](https://github.com/think-cell/range/pull/23) return_MAYTHROW(tc::continue_==tc::for_each(tc_move_if_owned(rng), tc::constexpr_function<tc::constanttc::break_{}>()));
^
./tc/range/../algorithm/../base/trivial_functors.h:26:17: note: template parameter is declared here
template
^
2 errors generated.