### PR TITLE
Add static_cast around return-statement of `tc::as_lvalue`

### DIFF
--- a/tc/base/as_lvalue.h
+++ b/tc/base/as_lvalue.h
@@ -16,6 +16,6 @@ namespace tc {
 
 	template< typename T >
 	[[nodiscard]] constexpr T& as_lvalue(T&& t) noexcept {
-		return t;
+		return static_cast<T&>(t);
 	}
 }


### PR DESCRIPTION
Due to https://wg21.link/p2266, the function `tc::as_lvalue` is (will be) ill-formed in C++23 mode. See also: https://eel.is/c++draft/diff.cpp20.expr#1. Adding the `static_cast<T&>` fixes it.